### PR TITLE
Edit README: to match laravel 5.5 SP syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require jacquestvanzuydam/laravel-firebird
 
 Update the `app/config/app.php`, add the service provider:
 ```json
-'Firebird\FirebirdServiceProvider'.
+'Firebird\FirebirdServiceProvider::class'.
 ```
 
 You can remove the original DatabaseServiceProvider, as the original connection factory has also been extended.


### PR DESCRIPTION
In laravel 5.5, to declare a Service provider in config/app.php, we shoul use a stitc call with '::'
that why it becomes: 
Firebird\FirebirdServiceProvider::class
instead of 
Firebird\FirebirdServiceProvider